### PR TITLE
Return jwt from `ensure_valid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ valid = validator.valid?(request.cookies[:token])
 
 # Raises errors when it cannot validate a given token.
 begin
-    validator.ensure_valid(request.cookies[:token])
+    # returns the decoded JWT
+    jwt = validator.ensure_valid(request.cookies[:token])
 rescue InvalidToken, InvalidKey, RequestError => e
     # do stuff
 end

--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -36,9 +36,7 @@ module Authentic
     #
     # Returns nothing.
     def ensure_valid(token)
-      jwt = decode_jwt(token)
-
-      begin
+      decode_jwt(token).tap do |jwt|
         key = manager.get(jwt)
 
         # Slightly more accurate to raise a key error here for nil key,
@@ -46,11 +44,11 @@ module Authentic
         raise InvalidKey, 'invalid JWK' if key.nil?
 
         jwt.verify!(key)
-      rescue JSON::JWT::UnexpectedAlgorithm, JSON::JWT::VerificationFailed
-        raise InvalidToken, 'failed to validate token against JWK'
-      rescue OpenSSL::PKey::PKeyError
-        raise InvalidKey, 'invalid JWK'
       end
+    rescue JSON::JWT::UnexpectedAlgorithm, JSON::JWT::VerificationFailed
+      raise InvalidToken, 'failed to validate token against JWK'
+    rescue OpenSSL::PKey::PKeyError
+      raise InvalidKey, 'invalid JWK'
     end
 
     # Decodes and does basic validation of JWT.

--- a/spec/lib/index_spec.rb
+++ b/spec/lib/index_spec.rb
@@ -99,6 +99,24 @@ describe 'Authentic' do
         expect { subject.ensure_valid(token) }.not_to raise_error
       end
 
+      it "returns the token body" do
+        token_body = {
+          "amr" => ["pwd"],
+          "aud"=>"0oadjyk523hlZfyb10h7",
+          "auth_time"=>1516637091,
+          "exp"=>1516640691,
+          "iat"=>1516637091,
+          "idp" => "00ocg4tbu6FK2Dh5G0h7",
+          "iss" => "https://authentic.articulate.com/",
+          "jti" => "ID.c8jhzoky0fFNPr8L_SCrrpgTTUyAoctHv69OKSmf5GA",
+          "nonce" => "2",
+          "sub"=>"00udjyjssbt2S1QVr0h7",
+          "tenantId"=>"d42e33fd-f05e-4a4e-9050-5b7b2e800834",
+          "ver"=>1
+        }
+        expect(subject.ensure_valid(token)).to eq(token_body)
+      end
+
       it 'raises error when invalid JWT is provided' do
         expect { subject.ensure_valid('sillygoose') }.to raise_error(Authentic::InvalidToken)
       end


### PR DESCRIPTION
If we successfully decode, we want to return the decoded token for later use.