### PR TITLE
adding exp claim verification

### DIFF
--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -43,9 +43,9 @@ module Authentic
         # rather then verify raising an error that would lead to InvalidToken
         raise InvalidKey, 'invalid JWK' if key.nil?
 
-        jwt.verify!(key)
+        raise InvalidToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
 
-        verify_claims(jwt)
+        jwt.verify!(key)
       end
     rescue JSON::JWT::UnexpectedAlgorithm, JSON::JWT::VerificationFailed
       raise InvalidToken, 'failed to validate token against JWK'
@@ -66,12 +66,6 @@ module Authentic
       end
     rescue JSON::JWT::InvalidFormat
       raise InvalidToken, 'invalid JWT format'
-    end
-
-    private
-
-    def verify_claims(jwt)
-      raise InvalidToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
     end
   end
 end

--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -44,6 +44,8 @@ module Authentic
         raise InvalidKey, 'invalid JWK' if key.nil?
 
         jwt.verify!(key)
+
+        verify_claims(jwt)
       end
     rescue JSON::JWT::UnexpectedAlgorithm, JSON::JWT::VerificationFailed
       raise InvalidToken, 'failed to validate token against JWK'
@@ -64,6 +66,12 @@ module Authentic
       end
     rescue JSON::JWT::InvalidFormat
       raise InvalidToken, 'invalid JWT format'
+    end
+
+    private
+
+    def verify_claims(jwt)
+      raise InvalidToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
     end
   end
 end


### PR DESCRIPTION
While picking up on some testing the next morning I realized that I was passing the `ensure_valid` test when my token's `exp` value had been passed.  Looking at JSON::JWT it looks like it leaves claim validation up to the user https://github.com/nov/json-jwt/wiki#decode--verify.

This PR adds validation of the `exp` claim to ensure that it's value is less than the current time.