### PR TITLE
Allow consumers to distinguish an expired token from an invalid one

### DIFF
--- a/lib/authentic/error.rb
+++ b/lib/authentic/error.rb
@@ -19,4 +19,7 @@ module Authentic
 
   # Public: Represents a bad JWT.
   class InvalidToken < StandardError; end
+
+  # Public: Represents an expired JWT.
+  class ExpiredToken < StandardError; end
 end

--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -25,7 +25,7 @@ module Authentic
     def valid?(token)
       ensure_valid(token)
       true
-    rescue InvalidToken, InvalidKey, RequestError
+    rescue InvalidToken, ExpiredToken, InvalidKey, RequestError
       false
     end
 
@@ -43,7 +43,7 @@ module Authentic
         # rather then verify raising an error that would lead to InvalidToken
         raise InvalidKey, 'invalid JWK' if key.nil?
 
-        raise InvalidToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
+        raise ExpiredToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
 
         jwt.verify!(key)
       end

--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -43,8 +43,8 @@ module Authentic
         # rather then verify raising an error that would lead to InvalidToken
         raise InvalidKey if key.nil?
 
-        exp = Time.at(jwt[:exp]).utc
-        raise ExpiredToken, "Token expired at #{exp}" unless exp > Time.now.utc
+        exp = Time.at(jwt[:exp])
+        raise ExpiredToken, "Token expired at #{exp}" unless exp > Time.now
 
         jwt.verify!(key)
       end

--- a/lib/authentic/validator.rb
+++ b/lib/authentic/validator.rb
@@ -41,16 +41,17 @@ module Authentic
 
         # Slightly more accurate to raise a key error here for nil key,
         # rather then verify raising an error that would lead to InvalidToken
-        raise InvalidKey, 'invalid JWK' if key.nil?
+        raise InvalidKey if key.nil?
 
-        raise ExpiredToken, 'expired JWT' unless Time.at(jwt[:exp]) > Time.now
+        exp = Time.at(jwt[:exp]).utc
+        raise ExpiredToken, "Token expired at #{exp}" unless exp > Time.now.utc
 
         jwt.verify!(key)
       end
     rescue JSON::JWT::UnexpectedAlgorithm, JSON::JWT::VerificationFailed
-      raise InvalidToken, 'failed to validate token against JWK'
+      raise InvalidToken, 'Failed to validate token against JWK'
     rescue OpenSSL::PKey::PKeyError
-      raise InvalidKey, 'invalid JWK'
+      raise InvalidKey
     end
 
     # Decodes and does basic validation of JWT.
@@ -59,13 +60,13 @@ module Authentic
     #
     # Returns JSON::JWT
     def decode_jwt(token)
-      raise InvalidToken, 'invalid nil JWT provided' unless token
+      raise InvalidToken, 'JWT was nil' unless token
 
       JSON::JWT.decode(token, :skip_verification).tap do |jwt|
         raise InvalidToken, 'JWT iss was not located in provided whitelist' unless iss_whitelist.include?(jwt[:iss])
       end
     rescue JSON::JWT::InvalidFormat
-      raise InvalidToken, 'invalid JWT format'
+      raise InvalidToken, 'JWT was in an invalid format'
     end
   end
 end

--- a/spec/lib/index_spec.rb
+++ b/spec/lib/index_spec.rb
@@ -41,7 +41,7 @@ describe 'Authentic' do
 
   before { stub_request(:get, test_url).to_return(body: oidc_file) }
   before { stub_request(:get, test_jwks_url).to_return(body: key_file) }
-  before { Timecop.travel(Time.new(2018, 01, 01)) } #token defined above expires on 2018/01/22
+  before { Timecop.travel(Time.new(2018, 01, 01).utc) } #token defined above expires on 2018/01/22
 
   after { Timecop.return }
 

--- a/spec/lib/index_spec.rb
+++ b/spec/lib/index_spec.rb
@@ -74,7 +74,7 @@ describe 'Authentic' do
         expect(a_request(:get, test_jwks_url)).to have_been_made.times(1)
       end
 
-      it 'fetches new JWT when cache expires' do
+      it 'fetches new JWK when cache expires' do
         # hydrates caches
         subject.valid?(token)
 
@@ -161,7 +161,7 @@ describe 'Authentic' do
 
       it 'raises an error when the current time is older than JWT.exp value' do
         Timecop.travel(Time.new(2019, 06, 01)) do
-          expect { subject.ensure_valid(token) }.to raise_error(Authentic::InvalidToken)
+          expect { subject.ensure_valid(token) }.to raise_error(Authentic::ExpiredToken)
         end
       end
     end

--- a/spec/lib/index_spec.rb
+++ b/spec/lib/index_spec.rb
@@ -41,7 +41,7 @@ describe 'Authentic' do
 
   before { stub_request(:get, test_url).to_return(body: oidc_file) }
   before { stub_request(:get, test_jwks_url).to_return(body: key_file) }
-  before { Timecop.travel(Time.new(2018, 01, 01).utc) } #token defined above expires on 2018/01/22
+  before { Timecop.travel(Time.new(2018, 01, 01)) } #token defined above expires on 2018/01/22
 
   after { Timecop.return }
 


### PR DESCRIPTION
Add new error for ExpiredToken, this will allow consumers to return the proper response code.